### PR TITLE
Added functionality for lot API endpoints to access the LOT table

### DIFF
--- a/Go/data/lot/lot.go
+++ b/Go/data/lot/lot.go
@@ -1,25 +1,112 @@
 package lot
 
 import (
+	"database/sql/driver"
+	"encoding/json"
+	"time"
+
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 )
 
-type Lot struct {
-	lotID     uuid.UUID `db:"lotid"`
-	Latitude  float64   `db:"latitude"`
-	Longitude float64   `db:"longitude"`
-	Address   string    `db:"address"`
+type psqlStrArray []string
+type psqlTime time.Time
+
+type InternalLot struct {
+	LotID     uuid.UUID    `json:"LotID"`
+	Latitude  float64      `json:"latitude"`
+	Longitude float64      `json:"longitude"`
+	Address   string       `json:"address"`
+	Open      psqlTime     `json:"open"`
+	Close     psqlTime     `json:"close"`
+	Days      psqlStrArray `json:"days"`
+	Decals    psqlStrArray `json:"decals"`
+	Occupancy int          `json:"occupancy"`
+	Capacity  int          `json:"capacity"`
+	Notes     string       `json:"notes"`
+	Verified  bool         `json:"verified"`
 }
 
-func New(_uuid uuid.UUID, _lon float64, _lat float64, _address string) *Lot {
+type Lot struct {
+	lotID     uuid.UUID
+	Latitude  float64      `json:"latitude"`
+	Longitude float64      `json:"longitude"`
+	Address   string       `json:"address"`
+	Open      psqlTime     `json:"open"`
+	Close     psqlTime     `json:"close"`
+	Days      psqlStrArray `json:"days"`
+	Decals    psqlStrArray `json:"decals"`
+	Occupancy int          `json:"occupancy"`
+	Capacity  int          `json:"capacity"`
+	Notes     string       `json:"notes"`
+	Verified  bool         `json:"verified"`
+}
+
+func New(_uuid uuid.UUID, _lon float64, _lat float64, _address string, _open time.Time, _close time.Time, _days []string, _decals []string, _occupancy int, _capacity int, _notes string, _verified bool) *Lot {
 	return &Lot{
 		lotID:     _uuid,
 		Latitude:  _lat,
 		Longitude: _lon,
 		Address:   _address,
+		Open:      psqlTime(_open),
+		Close:     psqlTime(_close),
+		Days:      _days,
+		Decals:    _decals,
+		Occupancy: _occupancy,
+		Capacity:  _capacity,
+		Notes:     _notes,
+		Verified:  _verified,
 	}
 }
 
 func (l *Lot) GetID() uuid.UUID {
 	return l.lotID
+}
+
+func (l *Lot) ConvertToInternalLot() *InternalLot {
+	return &InternalLot{
+		LotID:     l.GetID(),
+		Latitude:  l.Latitude,
+		Longitude: l.Longitude,
+		Address:   l.Address,
+		Open:      l.Open,
+		Close:     l.Close,
+		Days:      l.Days,
+		Decals:    l.Decals,
+		Occupancy: l.Occupancy,
+		Capacity:  l.Capacity,
+		Notes:     l.Notes,
+		Verified:  l.Verified,
+	}
+}
+
+func (s *psqlStrArray) ValueAsPSQLArray() driver.Value {
+	ret, err := pq.Array(*s).Value()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func (t *psqlTime) FormatAsPSQLTime() string {
+	return time.Time(*t).Format("15:04:00")
+}
+
+func (t *psqlTime) MarshalJSON() ([]byte, error) {
+	stringTime := time.Time(*t).Format("15:04:00")
+	return json.Marshal(stringTime)
+}
+
+func (t *psqlTime) UnmarshalJSON(b []byte) error {
+	var stringTime string
+	err := json.Unmarshal(b, &stringTime)
+	if err != nil {
+		return err
+	}
+	parsedTime, err := time.Parse("15:04:00", stringTime)
+	if err != nil {
+		return err
+	}
+	*t = psqlTime(parsedTime)
+	return nil
 }

--- a/Go/data/lot/lot.go
+++ b/Go/data/lot/lot.go
@@ -89,11 +89,11 @@ func (s *psqlStrArray) ValueAsPSQLArray() driver.Value {
 }
 
 func (t *psqlTime) FormatAsPSQLTime() string {
-	return time.Time(*t).Format("15:04:00")
+	return time.Time(*t).Format(time.TimeOnly)
 }
 
 func (t *psqlTime) MarshalJSON() ([]byte, error) {
-	stringTime := time.Time(*t).Format("15:04:00")
+	stringTime := time.Time(*t).Format(time.TimeOnly)
 	return json.Marshal(stringTime)
 }
 
@@ -103,7 +103,7 @@ func (t *psqlTime) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-	parsedTime, err := time.Parse("15:04:00", stringTime)
+	parsedTime, err := time.Parse(time.TimeOnly, stringTime)
 	if err != nil {
 		return err
 	}

--- a/Go/main.go
+++ b/Go/main.go
@@ -2,10 +2,9 @@
 
 // import (
 // 	"math/rand"
-// 	"strconv"
+// 	"time"
 
 // 	"backpacktech.com/LPD/data"
-// 	"backpacktech.com/LPD/data/car"
 // 	"backpacktech.com/LPD/data/lot"
 // 	"github.com/google/uuid"
 // )
@@ -47,9 +46,12 @@
 // 		data.DeleteCar(car.GetID(), &prodDB)
 // 	}
 
+// 	openTime := time.Now()
+// 	closeTime := time.Now()
+
 // 	// Create new lot
-// 	var testLot *lot.Lot = lot.New(uuid.New(), 0.0, 0.0, "1234 Main St")
-// 	println(testLot.Address)
+// 	var testLot *lot.Lot = lot.New(uuid.New(), rand.Float64(), rand.Float64(), "1234 Main St", openTime, closeTime, []string{"M", "T"}, []string{"Red", "Green"}, 0, 100, "test note", true)
+// 	println(testLot.GetID().String())
 
 // 	data.SaveLot(testLot, &prodDB)
 
@@ -66,7 +68,7 @@
 
 // 	// Create 10 lots
 // 	for i := 0; i < 10; i++ {
-// 		var testLot *lot.Lot = lot.New(uuid.New(), rand.Float64(), rand.Float64(), "1234 Main St")
+// 		var testLot *lot.Lot = lot.New(uuid.New(), rand.Float64(), rand.Float64(), "1234 Main St", openTime, closeTime, []string{"M", "T"}, []string{"Red", "Green"}, 0, 100, "test note", true)
 // 		data.SaveLot(testLot, &prodDB)
 // 	}
 
@@ -92,6 +94,12 @@ func main() {
 	router.POST("/saveCar", endpoints.SaveCar)
 	router.DELETE("/deleteCar", endpoints.DeleteCar)
 	router.PUT("/updateCar", endpoints.UpdateCar)
+
+	router.GET("/getLot", endpoints.GetLot)
+	router.GET("/getAllLots", endpoints.GetAllLots)
+	router.POST("/saveLot", endpoints.SaveLot)
+	router.DELETE("/deleteLot", endpoints.DeleteLot)
+	router.PUT("/updateLot", endpoints.UpdateLot)
 
 	router.Run(":8080")
 }


### PR DESCRIPTION
Erik requested that we start to make use of the LOTS table in the database so that Postgres acts as the single source of truth for the project. I made modifications to the existing LOTS table to represent this schema now:

<img width="1183" alt="image" src="https://github.com/user-attachments/assets/37a7374d-2809-4fc7-8425-0b8563652d43">

You can access the table by using the newly implemented API endpoints that replicate the use of the CARS API endpoints. In other words, the endpoints are as follows:
`GetLot`
`GetAllLots`
`UpdateLot`
`SaveLot`
`DeleteLot`

I have also updated the Postman collection which can be found in the #remote-software channel in the Discord